### PR TITLE
Ensure that message responses do not exceed max message size

### DIFF
--- a/cmd/koinos-block-store/main.go
+++ b/cmd/koinos-block-store/main.go
@@ -44,10 +44,11 @@ const (
 )
 
 const (
-	blockstoreRPC = "block_store"
-	blockAccept   = "koinos.block.accept"
-	appName       = "block_store"
-	logDir        = "logs"
+	blockstoreRPC  = "block_store"
+	blockAccept    = "koinos.block.accept"
+	appName        = "block_store"
+	logDir         = "logs"
+	maxMessageSize = 536870912
 )
 
 func main() {
@@ -151,6 +152,13 @@ func main() {
 
 		var outputBytes []byte
 		outputBytes, err = proto.Marshal(resp)
+
+		if len(outputBytes) > maxMessageSize {
+			eResp := rpc.ErrorResponse{Message: "Response would exceed maximum MQ message size"}
+			rErr := block_store.BlockStoreResponse_Error{Error: &eResp}
+			resp.Response = &rErr
+			outputBytes, err = proto.Marshal(resp)
+		}
 
 		return outputBytes, err
 	})

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dgraph-io/badger v1.6.2
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/koinos/koinos-log-golang v0.0.0-20210621202301-3310a8e5866b
-	github.com/koinos/koinos-mq-golang v0.0.0-20221024231917-d90ee8d48910
+	github.com/koinos/koinos-mq-golang v0.0.0-20221027182629-36e5cc1a3051
 	github.com/koinos/koinos-proto-golang v0.3.1-0.20220802205931-319ee3a6b490
 	github.com/koinos/koinos-util-golang v0.0.0-20220831225923-5ba6e0d4e7b9
 	github.com/multiformats/go-multihash v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/koinos/koinos-mq-golang v0.0.0-20221024231049-b4150a25ee26 h1:LLtnpKR
 github.com/koinos/koinos-mq-golang v0.0.0-20221024231049-b4150a25ee26/go.mod h1:N4U4Sja49OQuTKfjql3MEGL+2WtaprX0EbmvU0d3RPk=
 github.com/koinos/koinos-mq-golang v0.0.0-20221024231917-d90ee8d48910 h1:+S4O2Sx+PtrAn2UWhIKmwYt4+XrQqaAlH7KOLEbCgxM=
 github.com/koinos/koinos-mq-golang v0.0.0-20221024231917-d90ee8d48910/go.mod h1:N4U4Sja49OQuTKfjql3MEGL+2WtaprX0EbmvU0d3RPk=
+github.com/koinos/koinos-mq-golang v0.0.0-20221027182629-36e5cc1a3051 h1:VcgLeYwe3LW6j2VYBZ9l7S75MS+UGfxXhs7dsdGsb94=
+github.com/koinos/koinos-mq-golang v0.0.0-20221027182629-36e5cc1a3051/go.mod h1:N4U4Sja49OQuTKfjql3MEGL+2WtaprX0EbmvU0d3RPk=
 github.com/koinos/koinos-proto-golang v0.0.0-20210817202730-232f9d89dd0b/go.mod h1:X0JDk9LJhh3zXCTtKc0OLL9zUGbVk1HIGPKi/WLpFuE=
 github.com/koinos/koinos-proto-golang v0.2.1-0.20220203004644-1d7ca7362b45 h1:9zEZq0YOBR9UuHRLOBiOHGojTsLr/ZLjZq39BJUzqzw=
 github.com/koinos/koinos-proto-golang v0.2.1-0.20220203004644-1d7ca7362b45/go.mod h1:ZonOOdmZcuEbRdOqqdfYRA2I4szYHy5aKzUveMWXBog=

--- a/internal/bstore/reqhandler.go
+++ b/internal/bstore/reqhandler.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	highestBlockKey = 0x01
+	maxBlockRequest = 1000
 )
 
 // RequestHandler contains a backend object and handles requests
@@ -100,6 +101,10 @@ func (e *BlockHeightMismatch) Error() string {
 
 // GetBlocksByID returns blocks by block ID
 func (handler *RequestHandler) GetBlocksByID(req *block_store.GetBlocksByIdRequest) (*block_store.GetBlocksByIdResponse, error) {
+	if len(req.BlockIds) > maxBlockRequest {
+		return nil, fmt.Errorf("cannot request more than %v blocks", maxBlockRequest)
+	}
+
 	result := block_store.GetBlocksByIdResponse{}
 
 	result.BlockItems = make([]*block_store.BlockItem, len(req.BlockIds))
@@ -211,6 +216,9 @@ func (handler *RequestHandler) fillBlocks(
 
 // GetBlocksByHeight retuns blocks by block height
 func (handler *RequestHandler) GetBlocksByHeight(req *block_store.GetBlocksByHeightRequest) (*block_store.GetBlocksByHeightResponse, error) {
+	if req.GetNumBlocks() > maxBlockRequest {
+		return nil, fmt.Errorf("cannot request more than %v blocks", maxBlockRequest)
+	}
 
 	resp := block_store.GetBlocksByHeightResponse{}
 
@@ -571,7 +579,7 @@ func (handler *RequestHandler) HandleRequest(req *block_store.BlockStoreRequest)
 				response.Response = &respVal
 			}
 		default:
-			err = errors.New("Unknown request")
+			err = errors.New("unknown request")
 		}
 	} else {
 		err = errors.New("expected request was nil")


### PR DESCRIPTION
## Brief description
Ensure that block store responses do not exceed maximum message size.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

# Demonstration
```console
❯ curl -d '{"jsonrpc":"2.0", "method":"block_store.get_blocks_by_height", "params":{"head_block_id":"0x1220b91912f8cf99b7ef834873dad6aa093695acbc5cb366a6e3aa7eb1048b7b6164", "ancestor_start_height":1785236, "num_blocks":100000, "return_block":true, "return_receipt":true}, "id":0}' http://localhost:8080/
{"jsonrpc":"2.0","error":{"code":-32603,"message":"Response would exceed maximum MQ message size"},"id":0
```
